### PR TITLE
fix failing & add test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ kava-proxy-service
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+# coverage report converted to HTML
+cover.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,6 +96,14 @@ The e2e tests won't pass if the proxy service and it's dependencies aren't fully
 make ready e2e-test
 ```
 
+## Test Coverage Report
+
+The test commands `make test`, `make unit-test`, and `make e2e-test` generate a `cover.out` raw test coverage report. The coverage can be converted into a user-friendly webpage:
+
+```bash
+make show-coverage
+```
+
 ### Running specific tests only
 
 Often during iterative development you want to run only a specific test (or group of tests), the `it` target will allow you to do just that:

--- a/Makefile
+++ b/Makefile
@@ -37,22 +37,28 @@ publish: lint
 .PHONY: unit-test
 # run all unit tests
 unit-test:
-	go test -count=1 -v -cover --race ./... -run "^TestUnitTest*"
+	go test -count=1 -v -cover -coverprofile cover.out --race ./... -run "^TestUnitTest*"
 
 .PHONY: e2e-test
 # run tests that execute against a local or remote instance of the API
 e2e-test:
-	go test -count=1 -v -cover --race ./... -run "^TestE2ETest*"
+	go test -count=1 -v -cover -coverprofile cover.out --race ./... -run "^TestE2ETest*"
 
 .PHONY: it
 # run any test matching the provided pattern, can pass a regex or a string
 # of the exact test to run
 it : lint
-	go test -count=1 -v -cover --race ./... -run=".*${p}.*"
+	go test -count=1 -v -cover -coverprofile cover.out --race ./... -run=".*${p}.*"
+
+.PHONY: show-coverage
+# convert test coverage report to html & open in browser
+show-coverage:
+	go tool cover -html cover.out -o cover.html && open cover.html
 
 .PHONY: test
 # run all tests
-test: unit-test e2e-test
+test:
+	go test -count=1 -v -cover -coverprofile cover.out --race ./...
 
 .PHONY: up
 # start dockerized versions of the service and it's dependencies

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -17,7 +17,7 @@ var (
 	}()
 )
 
-func TestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValidRequest(t *testing.T) {
+func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValidRequest(t *testing.T) {
 	requestedBlockNumberHexEncoding := "0x2"
 	requestBlockNumber, valid := cosmosmath.NewIntFromString(requestedBlockNumberHexEncoding)
 
@@ -38,7 +38,7 @@ func TestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValidRequest(
 	assert.Equal(t, requestBlockNumber, blockNumber)
 }
 
-func TestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockNumberForTag(t *testing.T) {
+func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockNumberForTag(t *testing.T) {
 	requestedBlockTag := "latest"
 
 	validRequest := EVMRPCRequestEnvelope{
@@ -54,7 +54,7 @@ func TestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockNumberForTag(t *
 	assert.Equal(t, BlockTagToNumberCodec[requestedBlockTag], blockNumber)
 }
 
-func TestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenRequestMethodEmpty(t *testing.T) {
+func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenRequestMethodEmpty(t *testing.T) {
 	invalidRequest := EVMRPCRequestEnvelope{
 		Method: "",
 	}
@@ -64,7 +64,7 @@ func TestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenRequestMethodEmpty(t
 	assert.Equal(t, ErrInvalidEthAPIRequest, err)
 }
 
-func TestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenInvalidTypeForBlockNumber(t *testing.T) {
+func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenInvalidTypeForBlockNumber(t *testing.T) {
 	invalidRequest := EVMRPCRequestEnvelope{
 		Method: "eth_getBlockByNumber",
 		Params: []interface{}{
@@ -77,7 +77,7 @@ func TestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenInvalidTypeForBlockN
 	assert.NotNil(t, err)
 }
 
-func TestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenUnknownRequestMethod(t *testing.T) {
+func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenUnknownRequestMethod(t *testing.T) {
 	invalidRequest := EVMRPCRequestEnvelope{
 		Method: "eth_web4",
 		Params: []interface{}{

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	cosmosmath "cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,11 +18,7 @@ var (
 
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValidRequest(t *testing.T) {
 	requestedBlockNumberHexEncoding := "0x2"
-	requestBlockNumber, valid := cosmosmath.NewIntFromString(requestedBlockNumberHexEncoding)
-
-	if !valid {
-		t.Fatalf("failed to convert %s to cosmos sdk int", requestedBlockNumberHexEncoding)
-	}
+	expectedBlockNumber := int64(2)
 
 	validRequest := EVMRPCRequestEnvelope{
 		Method: "eth_getBlockByNumber",
@@ -35,7 +30,7 @@ func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValid
 	blockNumber, err := validRequest.ExtractBlockNumberFromEVMRPCRequest(testContext, dummyEthClient)
 
 	assert.Nil(t, err)
-	assert.Equal(t, requestBlockNumber, blockNumber)
+	assert.Equal(t, expectedBlockNumber, blockNumber)
 }
 
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockNumberForTag(t *testing.T) {
@@ -87,5 +82,5 @@ func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenUnknownReque
 
 	_, err := invalidRequest.ExtractBlockNumberFromEVMRPCRequest(testContext, dummyEthClient)
 
-	assert.Equal(t, ErrUncachaebleEthRequest, err)
+	assert.Equal(t, ErrUncachaebleByBlockNumberEthRequest, err)
 }


### PR DESCRIPTION
Getting acquainted with the codebase to start working on node sharding, I noticed some tests that weren't covered by `make test` because the test methods don't begin with `TestUnitTest`.

* update those test names
* fix test failures in those tests
* updated `make test` to run _all_ tests, even if they aren't prefixed with `TestUnitTest` or `TestE2ETest`
* added code coverage reporting for giggles