### PR TITLE
improve & refactor evm_rpc methods for reuse

### DIFF
--- a/decode/evm_rpc.go
+++ b/decode/evm_rpc.go
@@ -60,9 +60,9 @@ var CacheableByBlockHashMethods = []string{
 	"eth_getTransactionByBlockHashAndIndex",
 }
 
-// List of evm methods that can always be safely routed to an up-to-date pruning cluster.
-// These are methods that rely only on the present state of the chain.
-var AlwaysLatestHeightMethods = []string{
+// NoHistoryMethods is a list of JSON-RPC methods that rely only on the present state of the chain.
+// They can always be safely routed to an up-to-date pruning cluster.
+var NoHistoryMethods = []string{
 	"web3_clientVersion",
 	"web3_sha3",
 	"net_version",
@@ -82,12 +82,12 @@ var AlwaysLatestHeightMethods = []string{
 	"eth_sendRawTransaction",
 }
 
-// IsAlwaysLatestHeightMethod returns true when a JSON-RPC method always functions correctly
+// MethodRequiresNoHistory returns true when the JSON-RPC method always functions correctly
 // when sent to the latest block.
-// This is useful for determining if a request can be made to a pruning cluster.
-func IsAlwaysLatestHeightMethod(method string) bool {
-	for _, alwaysLatestMethod := range AlwaysLatestHeightMethods {
-		if method == alwaysLatestMethod {
+// This is useful for determining if a request can be routed to a pruning cluster.
+func MethodRequiresNoHistory(method string) bool {
+	for _, nonHistoricalMethod := range NoHistoryMethods {
+		if method == nonHistoricalMethod {
 			return true
 		}
 	}

--- a/decode/evm_rpc.go
+++ b/decode/evm_rpc.go
@@ -258,6 +258,8 @@ func lookupBlockNumberFromHashParam(ctx context.Context, evmClient *ethclient.Cl
 }
 
 // Generic method to parse the block number from a set of params
+// errors if method does not have a block number in the param, or the param has an unexpected value
+// block tags are encoded to an int64 according to the BlockTagToNumberCodec map.
 func ParseBlockNumberFromParams(methodName string, params []interface{}) (int64, error) {
 	paramIndex, exists := MethodNameToBlockNumberParamIndex[methodName]
 

--- a/decode/evm_rpc.go
+++ b/decode/evm_rpc.go
@@ -147,6 +147,11 @@ var BlockTagToNumberCodec = map[string]int64{
 	"earliest":  -3,
 	"finalized": -4,
 	"safe":      -5,
+	// "empty" is not part of the evm json-rpc spec
+	// it is our encoding for when no parameter is passed in as a block tag param
+	// usually, clients interpret an empty block tag to mean "latest"
+	// we track it separately here to more accurately track how users make requests
+	"empty": -6,
 }
 
 // EVMRPCRequest wraps expected values present in a request
@@ -250,10 +255,9 @@ func ParseBlockNumberFromParams(methodName string, params []interface{}) (int64,
 		return 0, ErrUncachaebleByBlockNumberEthRequest
 	}
 
-	// TODO: IS THIS TRUE?
-	// an empty block tag is the equivalent of requesting latest.
+	// capture requests made with empty block tag params
 	if params[paramIndex] == nil {
-		return BlockTagToNumberCodec["latest"], nil
+		return BlockTagToNumberCodec["empty"], nil
 	}
 
 	tag, isString := params[paramIndex].(string)

--- a/decode/evm_rpc.go
+++ b/decode/evm_rpc.go
@@ -106,10 +106,13 @@ var MethodNameToBlockHashParamIndex = map[string]int{
 // Mapping of string tag values used in the eth api to
 // normalized int values that can be stored as the block number
 // for the proxied request metric
+// see https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block
 var BlockTagToNumberCodec = map[string]int64{
-	"latest":   -1,
-	"pending":  -2,
-	"earliest": -3,
+	"latest":    -1,
+	"pending":   -2,
+	"earliest":  -3,
+	"finalized": -4,
+	"safe":      -5,
 }
 
 // EVMRPCRequest wraps expected values present in a request
@@ -214,22 +217,16 @@ func parseBlockNumberFromParams(methodName string, params []interface{}) (int64,
 		return 0, fmt.Errorf(fmt.Sprintf("error decoding block number param from params %+v at index %d", params, paramIndex))
 	}
 
-	var blockNumber int64
-	tagEncoding, exists := BlockTagToNumberCodec[tag]
+	blockNumber, exists := BlockTagToNumberCodec[tag]
 
 	if !exists {
 		spaceint, valid := cosmosmath.NewIntFromString(tag)
-
 		if !valid {
 			return 0, fmt.Errorf(fmt.Sprintf("unable to parse tag %s to integer", tag))
 		}
 
 		blockNumber = spaceint.Int64()
-
-		return blockNumber, nil
 	}
-
-	blockNumber = tagEncoding
 
 	return blockNumber, nil
 }

--- a/decode/evm_rpc.go
+++ b/decode/evm_rpc.go
@@ -12,6 +12,18 @@ import (
 	cosmosmath "cosmossdk.io/math"
 )
 
+// These block tags are special strings used to reference blocks in JSON-RPC
+// see https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block
+const (
+	BlockTagLatest    = "latest"
+	BlockTagPending   = "pending"
+	BlockTagEarliest  = "earliest"
+	BlockTagFinalized = "finalized"
+	BlockTagSafe      = "safe"
+	// "empty" is not in the spec, it is our encoding for requests made with a nil block tag param.
+	BlockTagEmpty = "empty"
+)
+
 // Errors that might result from decoding parts or the whole of
 // an EVM RPC request
 var (
@@ -142,16 +154,16 @@ var MethodNameToBlockHashParamIndex = map[string]int{
 // for the proxied request metric
 // see https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block
 var BlockTagToNumberCodec = map[string]int64{
-	"latest":    -1,
-	"pending":   -2,
-	"earliest":  -3,
-	"finalized": -4,
-	"safe":      -5,
+	BlockTagLatest:    -1,
+	BlockTagPending:   -2,
+	BlockTagEarliest:  -3,
+	BlockTagFinalized: -4,
+	BlockTagSafe:      -5,
 	// "empty" is not part of the evm json-rpc spec
 	// it is our encoding for when no parameter is passed in as a block tag param
 	// usually, clients interpret an empty block tag to mean "latest"
 	// we track it separately here to more accurately track how users make requests
-	"empty": -6,
+	BlockTagEmpty: -6,
 }
 
 // EVMRPCRequest wraps expected values present in a request

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -34,19 +34,21 @@ func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValid
 }
 
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockNumberForTag(t *testing.T) {
-	requestedBlockTag := "latest"
+	tags := []string{"latest", "pending", "earliest", "finalized", "safe"}
 
-	validRequest := EVMRPCRequestEnvelope{
-		Method: "eth_getBlockByNumber",
-		Params: []interface{}{
-			requestedBlockTag, false,
-		},
+	for _, requestedBlockTag := range tags {
+		validRequest := EVMRPCRequestEnvelope{
+			Method: "eth_getBlockByNumber",
+			Params: []interface{}{
+				requestedBlockTag, false,
+			},
+		}
+
+		blockNumber, err := validRequest.ExtractBlockNumberFromEVMRPCRequest(testContext, dummyEthClient)
+
+		assert.Nil(t, err)
+		assert.Equal(t, BlockTagToNumberCodec[requestedBlockTag], blockNumber)
 	}
-
-	blockNumber, err := validRequest.ExtractBlockNumberFromEVMRPCRequest(testContext, dummyEthClient)
-
-	assert.Nil(t, err)
-	assert.Equal(t, BlockTagToNumberCodec[requestedBlockTag], blockNumber)
 }
 
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenRequestMethodEmpty(t *testing.T) {

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -51,6 +51,20 @@ func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockNumberFo
 	}
 }
 
+func TestUnitTestExtractBlockNumberFromEVMRPCRequestFailsForInvalidTag(t *testing.T) {
+	requestedBlockTag := "invalid-block-tag"
+	validRequest := EVMRPCRequestEnvelope{
+		Method: "eth_getBlockByNumber",
+		Params: []interface{}{
+			requestedBlockTag, false,
+		},
+	}
+
+	_, err := validRequest.ExtractBlockNumberFromEVMRPCRequest(testContext, dummyEthClient)
+
+	assert.ErrorContains(t, err, "unable to parse tag")
+}
+
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenRequestMethodEmpty(t *testing.T) {
 	invalidRequest := EVMRPCRequestEnvelope{
 		Method: "",

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -15,6 +16,36 @@ var (
 		return &client
 	}()
 )
+
+func TestUnitTest_CacheableParamValidation(t *testing.T) {
+	blockNumReq := EVMRPCRequestEnvelope{
+		Method: "eth_getBlockByNumber",
+		Params: []interface{}{"latest", false},
+	}
+	require.True(t, blockNumReq.HasBlockNumberParam())
+	require.False(t, blockNumReq.HasBlockHashParam())
+
+	blockHashReq := EVMRPCRequestEnvelope{
+		Method: "eth_getBlockByHash",
+		Params: []interface{}{"0x7d79bac29793ff9b430debd43309875766afaa61e6f49841d33019b1502fea47", false},
+	}
+	require.True(t, blockHashReq.HasBlockHashParam())
+	require.False(t, blockHashReq.HasBlockNumberParam())
+
+	invalidReq := EVMRPCRequestEnvelope{
+		Method: "eth_notRealMethod",
+		Params: []interface{}{},
+	}
+	require.False(t, invalidReq.HasBlockNumberParam())
+	require.False(t, invalidReq.HasBlockHashParam())
+
+	emptyReq := EVMRPCRequestEnvelope{
+		Method: "",
+		Params: []interface{}{},
+	}
+	require.False(t, emptyReq.HasBlockNumberParam())
+	require.False(t, emptyReq.HasBlockHashParam())
+}
 
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValidRequest(t *testing.T) {
 	requestedBlockNumberHexEncoding := "0x2"

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -18,33 +18,44 @@ var (
 )
 
 func TestUnitTest_CacheableParamValidation(t *testing.T) {
-	blockNumReq := EVMRPCRequestEnvelope{
-		Method: "eth_getBlockByNumber",
-		Params: []interface{}{"latest", false},
+	testCases := []struct {
+		name           string
+		method         string
+		hasBlockNumber bool
+		hasBlockHash   bool
+	}{
+		{
+			name:           "block number method",
+			method:         "eth_getBlockByNumber",
+			hasBlockNumber: true,
+			hasBlockHash:   false,
+		},
+		{
+			name:           "block hash method",
+			method:         "eth_getBlockByHash",
+			hasBlockNumber: false,
+			hasBlockHash:   true,
+		},
+		{
+			name:           "invalid method",
+			method:         "eth_notRealMethod",
+			hasBlockNumber: false,
+			hasBlockHash:   false,
+		},
+		{
+			name:           "empty method",
+			method:         "",
+			hasBlockNumber: false,
+			hasBlockHash:   false,
+		},
 	}
-	require.True(t, blockNumReq.HasBlockNumberParam())
-	require.False(t, blockNumReq.HasBlockHashParam())
 
-	blockHashReq := EVMRPCRequestEnvelope{
-		Method: "eth_getBlockByHash",
-		Params: []interface{}{"0x7d79bac29793ff9b430debd43309875766afaa61e6f49841d33019b1502fea47", false},
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.hasBlockNumber, MethodHasBlockNumberParam(tc.method), "unexpected MethodHasBlockNumberParam result")
+			require.Equal(t, tc.hasBlockHash, MethodHasBlockHashParam(tc.method), "unexpected MethodHasBlockHashParam result")
+		})
 	}
-	require.True(t, blockHashReq.HasBlockHashParam())
-	require.False(t, blockHashReq.HasBlockNumberParam())
-
-	invalidReq := EVMRPCRequestEnvelope{
-		Method: "eth_notRealMethod",
-		Params: []interface{}{},
-	}
-	require.False(t, invalidReq.HasBlockNumberParam())
-	require.False(t, invalidReq.HasBlockHashParam())
-
-	emptyReq := EVMRPCRequestEnvelope{
-		Method: "",
-		Params: []interface{}{},
-	}
-	require.False(t, emptyReq.HasBlockNumberParam())
-	require.False(t, emptyReq.HasBlockHashParam())
 }
 
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockForValidRequest(t *testing.T) {

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -17,36 +17,48 @@ var (
 	}()
 )
 
-func TestUnitTest_CacheableParamValidation(t *testing.T) {
+func TestUnitTest_MethodCategorization(t *testing.T) {
 	testCases := []struct {
 		name           string
 		method         string
 		hasBlockNumber bool
 		hasBlockHash   bool
+		needsNoHistory bool
 	}{
 		{
 			name:           "block number method",
 			method:         "eth_getBlockByNumber",
 			hasBlockNumber: true,
 			hasBlockHash:   false,
+			needsNoHistory: false,
 		},
 		{
 			name:           "block hash method",
 			method:         "eth_getBlockByHash",
 			hasBlockNumber: false,
 			hasBlockHash:   true,
+			needsNoHistory: false,
+		},
+		{
+			name:           "needs no history",
+			method:         "eth_sendTransaction",
+			hasBlockNumber: false,
+			hasBlockHash:   false,
+			needsNoHistory: true,
 		},
 		{
 			name:           "invalid method",
 			method:         "eth_notRealMethod",
 			hasBlockNumber: false,
 			hasBlockHash:   false,
+			needsNoHistory: false,
 		},
 		{
 			name:           "empty method",
 			method:         "",
 			hasBlockNumber: false,
 			hasBlockHash:   false,
+			needsNoHistory: false,
 		},
 	}
 
@@ -54,6 +66,7 @@ func TestUnitTest_CacheableParamValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.hasBlockNumber, MethodHasBlockNumberParam(tc.method), "unexpected MethodHasBlockNumberParam result")
 			require.Equal(t, tc.hasBlockHash, MethodHasBlockHashParam(tc.method), "unexpected MethodHasBlockHashParam result")
+			require.Equal(t, tc.needsNoHistory, MethodRequiresNoHistory(tc.method), "unexpected MethodRequiresNoHistory result")
 		})
 	}
 }
@@ -91,6 +104,19 @@ func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsExpectedBlockNumberFo
 		assert.Nil(t, err)
 		assert.Equal(t, BlockTagToNumberCodec[requestedBlockTag], blockNumber)
 	}
+
+	// check empty block number
+	validRequest := EVMRPCRequestEnvelope{
+		Method: "eth_getBlockByNumber",
+		Params: []interface{}{
+			nil, false,
+		},
+	}
+
+	blockNumber, err := validRequest.ExtractBlockNumberFromEVMRPCRequest(testContext, dummyEthClient)
+
+	assert.Nil(t, err)
+	assert.Equal(t, BlockTagToNumberCodec["empty"], blockNumber)
 }
 
 func TestUnitTestExtractBlockNumberFromEVMRPCRequestFailsForInvalidTag(t *testing.T) {
@@ -141,4 +167,92 @@ func TestUnitTestExtractBlockNumberFromEVMRPCRequestReturnsErrorWhenUnknownReque
 	_, err := invalidRequest.ExtractBlockNumberFromEVMRPCRequest(testContext, dummyEthClient)
 
 	assert.Equal(t, ErrUncachaebleByBlockNumberEthRequest, err)
+}
+
+func TestUnitTest_ParseBlockNumberFromParams(t *testing.T) {
+	testCases := []struct {
+		name                string
+		req                 EVMRPCRequestEnvelope
+		expectedBlockNumber int64
+		expectedErr         string
+	}{
+		{
+			name: "method with block number",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{
+					"0xd", false,
+				},
+			},
+			expectedBlockNumber: 13,
+			expectedErr:         "",
+		},
+		{
+			name: "method with block tag",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{
+					"latest", false,
+				},
+			},
+			expectedBlockNumber: BlockTagToNumberCodec[BlockTagLatest],
+			expectedErr:         "",
+		},
+		{
+			name: "method with no block number in params",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByHash",
+				Params: []interface{}{
+					"0xb8d6ffd1ebd2df7a735c72e755886c6dd6587e096ae788558c6f24f31469b271", false,
+				},
+			},
+			expectedBlockNumber: 0,
+			expectedErr:         "request is not cache-able by block number",
+		},
+		{
+			name: "method with empty block number",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{
+					nil, false,
+				},
+			},
+			expectedBlockNumber: BlockTagToNumberCodec[BlockTagEmpty],
+			expectedErr:         "",
+		},
+		{
+			name: "method with invalid string block number param",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{
+					"not-an-int", false,
+				},
+			},
+			expectedBlockNumber: 0,
+			expectedErr:         "unable to parse tag not-an-int to integer",
+		},
+		{
+			name: "method with non-string block number param",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{
+					false, false,
+				},
+			},
+			expectedBlockNumber: 0,
+			expectedErr:         "error decoding block number param from params",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			blockNumber, err := ParseBlockNumberFromParams(tc.req.Method, tc.req.Params)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErr)
+			}
+			require.Equal(t, tc.expectedBlockNumber, blockNumber)
+		})
+	}
 }


### PR DESCRIPTION
I've implemented a sharding setup that routes requests for latest blocks (and other calls that can be made with no historical data) to a configurable pruning cluster.

In order to make that code more easily reviewable (and give me more time to write documentation 😄), I've pulled out all the changes I made to the decode package.

**changes**
* block tag changes
  * adds `"finalized"` and `"safe"` block tags
  * adds tracking for when `null` is passed as a block number. this is undefined behavior in the spec, but is regularly interpreted by clients to mean "latest". instead of erroring because it can't convert `nil` to a string, the block number parsing now encodes it to a special value so we can track requests made with no value in the block number param position in metrics
* adds new category of JSON-RPC methods: `NoHistoryMethods`
  * these methods require no historical state and thus can always be safely routed to pruning clusters
  * the categorization exists in this PR, but remains unused until i incorporate the sharding proxy changes
* refactors and makes public various pieces used to extract the block number from the params of supported requests
* increases overall test coverage of block number extraction 