### PR TITLE
account for partition gap when metric collection is flipped periodically

### DIFF
--- a/architecture/METRIC_COMPACTION_ROUTINE.md
+++ b/architecture/METRIC_COMPACTION_ROUTINE.md
@@ -11,7 +11,7 @@ The Metric Pruning routine is responsible for deleting any metrics that are olde
 ```bash
 # Whether metric pruning routines should run on the configured interval, defaults to true
 METRIC_PRUNING_ENABLED=true
-# How frequenlty metric pruning routines should run
+# How frequently metric pruning routines should run
 # defaults to 1 day
 METRIC_PRUNING_ROUTINE_INTERVAL_SECONDS=10
 # how long (after the proxy service starts) it will wait

--- a/routines/metric_partitioning.go
+++ b/routines/metric_partitioning.go
@@ -115,7 +115,8 @@ func partitionsForPeriod(start time.Time, numDaysToPrefill int) ([]PartitionPeri
 
 	daysInCurrentMonth := daysInMonth(start)
 
-	newDaysRemainingInCurrentMonth := daysInCurrentMonth - currentDay
+	// add one to include the current day
+	newDaysRemainingInCurrentMonth := daysInCurrentMonth - currentDay + 1
 
 	// generate partitions for current month
 	totalPartitionsToGenerate := numDaysToPrefill


### PR DESCRIPTION
when proxy service was first deployed we created first months partitions manually
partitioning routine ran every day and created next day(s) partitions
when metric collection was stopped, partitions stopped being created, causing a gap when metric collection was turned on again