### PR TITLE
fix: add CORs headers to cache hit responses

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -500,6 +500,10 @@ func TestE2ETestCachingMdwWithBlockNumberParam(t *testing.T) {
 			expectKeysNum(t, redisClient, tc.keysNum)
 			containsKey(t, redisClient, expectedKey)
 
+			// verify expected CORs headers added on cache hit
+			require.Equal(t, "*", resp2.Header.Get("Access-Control-Allow-Origin"))
+			require.Equal(t, "Content-Length", resp2.Header.Get("Access-Control-Expose-Headers"))
+
 			require.JSONEq(t, string(body1), string(body2), "blocks should be the same")
 		})
 	}

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -250,6 +250,11 @@ func createProxyRequestMiddleware(next http.Handler, config config.Config, servi
 
 				w.Header().Add(cachemdw.CacheHeaderKey, cachemdw.CacheHitHeaderValue)
 				w.Header().Add("Content-Type", "application/json")
+
+				// TODO: response headers should probably be cached with the original response
+				w.Header().Add("Access-Control-Allow-Origin", "*")
+				w.Header().Add("Access-Control-Expose-Headers", "Content-Length")
+
 				_, err := w.Write(typedCachedResponse)
 				if err != nil {
 					serviceLogger.Logger.Error().Msg(fmt.Sprintf("can't write cached response: %v", err))


### PR DESCRIPTION
if CORs is enabled in the underly nginx proxy, it adds necessary CORs headers to the response.

when the proxy service finds a cache hit, it does not add any CORs related header (or any of the originally cached request's response headers). thus, on cache hits, responses that would otherwise be allowed by CORs are rejected.

as a temporary fix to this, i've added appropriate CORs headers to all responses from cache hits. long-term, some response headers should get cached with the result data.