### PR TITLE
revert force-set of CORS header on cache misses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ up:
 .PHONY: down
 # stop the service and it's dependencies
 down:
-	rm docker/shared/genesis.json
-	rm docker/shared/VALIDATOR_NODE_ID
+	rm docker/shared/genesis.json || echo no shared genesis present
+	rm docker/shared/VALIDATOR_NODE_ID || echo no shared validator node id present
 	docker compose down
 
 .PHONY: restart

--- a/ci.docker-compose.yml
+++ b/ci.docker-compose.yml
@@ -22,7 +22,7 @@ services:
       dockerfile: ci.Dockerfile
     env_file: .env
     environment:
-      PROXY_HEIGHT_BASED_ROUTING_ENABLED: true
+      PROXY_HEIGHT_BASED_ROUTING_ENABLED: "true"
       # use public testnet as backend origin server to avoid having
       # to self-host a beefy Github Action runner
       # to build and run a kava node each execution

--- a/main_batch_test.go
+++ b/main_batch_test.go
@@ -225,8 +225,10 @@ func TestE2ETest_ValidBatchEvmRequests(t *testing.T) {
 			// check expected cache status header
 			require.Equal(t, tc.expectedCacheHeader, resp.Header.Get(cachemdw.CacheHeaderKey))
 
-			// verify CORS header
-			require.Equal(t, resp.Header[accessControlAllowOriginHeaderName], []string{"*"})
+			// verify CORS header (only on cache hits. cache misses return the backend value, if set)
+			if tc.expectedCacheHeader == cachemdw.CacheHitHeaderValue {
+				require.Equal(t, resp.Header[accessControlAllowOriginHeaderName], []string{"*"})
+			}
 
 			// wait for all metrics to be created.
 			// besides verification, waiting for the metrics ensures future tests don't fail b/c metrics are being processed

--- a/main_test.go
+++ b/main_test.go
@@ -525,7 +525,7 @@ func TestE2ETestCachingMdwWithBlockNumberParam(t *testing.T) {
 			expectKeysNum(t, redisClient, tc.keysNum)
 			expectedKey := "local-chain:evm-request:eth_getBlockByNumber:sha256:d08b426164eacf6646fb1817403ec0af5d37869a0f32a01ebfab3096fa4999be"
 			containsKey(t, redisClient, expectedKey)
-			require.Equal(t, cacheMissResp.Header[accessControlAllowOriginHeaderName], []string{"*"})
+			// don't check CORs because proxy only force-sets header for cache hits.
 
 			// eth_getBlockByNumber - cache HIT
 			cacheHitResp := mkJsonRpcRequest(t, proxyServiceURL, 1, tc.method, tc.params)

--- a/service/batchmdw/batch_processor.go
+++ b/service/batchmdw/batch_processor.go
@@ -109,7 +109,7 @@ func (bp *BatchProcessor) applyHeaders(h http.Header) {
 		// clear content length, will be set by actual Write to client
 		// must be cleared in order to prevent premature end of client read
 		bp.header.Del("Content-Length")
-		// clear cache hit header, will be set by flush()
+		// clear cache hit header, will be set by RequestAndServe()
 		bp.header.Del(cachemdw.CacheHeaderKey)
 	}
 


### PR DESCRIPTION
CORs headers are expected to be managed by the backend. However, for cached requests, we want to ensure that CORs is being set properly. This commit reverts setting the CORs header on cache misses. Additionally, it removes the tests that expect a CORs header on cache misses.