### PR TITLE
recover from panics during batch sub-requests

### DIFF
--- a/service/shard.go
+++ b/service/shard.go
@@ -30,7 +30,7 @@ func (hsp HeightShardingProxies) ProxyForRequest(r *http.Request) (*httputil.Rev
 	_, _, found := hsp.pruningProxies.ProxyForRequest(r)
 	// if the host isn't in the pruning proxies, short circuit fallback to default
 	if !found {
-		hsp.Debug().Msg(fmt.Sprintf("no pruning host backend configured for %s", r.Host))
+		hsp.Trace().Msg(fmt.Sprintf("no pruning host backend configured for %s", r.Host))
 		return hsp.defaultProxies.ProxyForRequest(r)
 	}
 


### PR DESCRIPTION
Makes a few adjustments to resolve an edge case panic that results from premature closure of HTTP2 connections during batch EVM requests.

When a connection is prematurely closed, requests are cancelled mid-flight. Because sub-requests of batches are broken into separate requests with new ResponseWriters, an un-recovered abort handler panic occurs ([ErrAbortHandler](https://pkg.go.dev/net/http#ErrAbortHandler)) when the client connection closure destroys the go funcs managing the sub-requests. Normally, the http.Server recovers from these types of panics without intervention. However, due to how the sub-requests are proxied (one request can create up to `PROXY_MAXIMUM_REQ_BATCH_SIZE` sub-requests), no recovery is made.

This PR adds a deferred recovery from panics that occur downstream of the batch processing middleware. This prevents panics that look like this in live deployments:
```
httputil: ReverseProxy read error during body copy: http2: client connection force closed via ClientConn.Close
panic: net/http: abort Handler
```