### PR TITLE
Fix panic when block tag greater than MaxInt64 is provided in parameters

### DIFF
--- a/decode/evm_rpc.go
+++ b/decode/evm_rpc.go
@@ -333,15 +333,24 @@ func ParseBlockNumberFromParams(methodName string, params []interface{}) (int64,
 	}
 
 	blockNumber, exists := BlockTagToNumberCodec[tag]
-
-	if !exists {
-		spaceint, valid := cosmosmath.NewIntFromString(tag)
-		if !valid {
-			return 0, fmt.Errorf(fmt.Sprintf("unable to parse tag %s to integer", tag))
-		}
-
-		blockNumber = spaceint.Int64()
+	if exists {
+		return blockNumber, nil
 	}
 
-	return blockNumber, nil
+	return blockParamToInt64(tag)
+}
+
+// blockParamToInt64 converts a 0x prefixed base 16 or no-prefixed base 10 string to int64
+// and returns an error if value is unable to be converted or out of bounds
+func blockParamToInt64(blockParam string) (int64, error) {
+	result, valid := cosmosmath.NewIntFromString(blockParam)
+	if !valid {
+		return 0, fmt.Errorf("unable to parse tag %s to integer", blockParam)
+	}
+
+	if !result.IsInt64() {
+		return 0, fmt.Errorf("value %s out of range", blockParam)
+	}
+
+	return result.Int64(), nil
 }

--- a/decode/evm_rpc_test.go
+++ b/decode/evm_rpc_test.go
@@ -242,6 +242,28 @@ func TestUnitTest_ParseBlockNumberFromParams(t *testing.T) {
 			expectedBlockNumber: 0,
 			expectedErr:         "error decoding block number param from params",
 		},
+		{
+			name: "errors on base10 int64 overflow",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{
+					"9223372036854775808", false,
+				},
+			},
+			expectedBlockNumber: 0,
+			expectedErr:         "out of range",
+		},
+		{
+			name: "errors on base16 int64 overflow",
+			req: EVMRPCRequestEnvelope{
+				Method: "eth_getBlockByNumber",
+				Params: []interface{}{
+					"0x8000000000000000", false,
+				},
+			},
+			expectedBlockNumber: 0,
+			expectedErr:         "out of range",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This adds a `IsInt64` check to the parsed `cosmosmath.Int` before `Int64()` conversion to prevent a panic.

Also, refactored the logic to improve readability and push this parsing complexity into it's own private method with doc comment.